### PR TITLE
Add a rudimentary date range picker

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,5 +37,5 @@ jobs:
 
     - name: Run tests
       run: |
-        coverage run -m pytest test_referrers.py test_utils.py
+        coverage run -m pytest test_app.py test_referrers.py test_utils.py
         coverage report

--- a/app.py
+++ b/app.py
@@ -241,7 +241,9 @@ class AnalyticsDatabase:
 
         return list(cursor)
 
-    def count_referrers(self, start_date: datetime.date, end_date: datetime.date) -> list[tuple[str, dict[str, int]]]:
+    def count_referrers(
+        self, start_date: datetime.date, end_date: datetime.date
+    ) -> list[tuple[str, dict[str, int]]]:
         """
         Get a list of referrers, grouped by source.  The entries look
         something like

--- a/app.py
+++ b/app.py
@@ -431,6 +431,19 @@ def prettydate(d: str) -> str:
 @app.route("/dashboard/")
 def dashboard():
     by_date = count_requests_by_day()
+    try:
+        start_date = datetime.date.fromisoformat(request.args["startDate"])
+        start_is_default = False
+    except KeyError:
+        start_date = datetime.date.today() - datetime.timedelta(days=29)
+        start_is_default = True
+
+    try:
+        end_date = datetime.date.fromisoformat(request.args["endDate"])
+        end_is_default = False
+    except KeyError:
+        end_date = datetime.date.today()
+        end_is_default = True
 
     unique_users = count_unique_visitors()
 
@@ -453,6 +466,10 @@ def dashboard():
 
     return render_template(
         "dashboard.html",
+        start=start_date,
+        end=end_date,
+        start_is_default=start_is_default,
+        end_is_default=end_is_default,
         by_date=sorted(by_date, key=lambda row: row["day"]),
         unique_users=sorted(unique_users, key=lambda row: row["day"]),
         popular_pages=popular_pages,

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -14,6 +14,46 @@
 {% endblock %}
 
 {% block content %}
+  <script>
+    function updateDates() {
+      const startDate = document.querySelector("#startDate").value;
+      const endDate = document.querySelector("#endDate").value;
+
+      var url = "/dashboard/";
+
+      if (startDate !== "" && endDate !== "") {
+        url += `?startDate=${startDate}&endDate=${endDate}`;
+      } else if (startDate !== "") {
+        url += `?startDate=${startDate}`;
+      } else if (endDate !== "") {
+        url += `?endDate=${endDate}`;
+      }
+
+      window.location = url;
+    }
+  </script>
+
+  <section style="grid-column: 1 / span 2;">
+    Get hits from:
+    <input
+      id="startDate"
+      type="date"
+      {% if start_is_default %}
+      placeholder="{{ start.isoformat() }}"
+      {% else %}
+      value="{{ start.isoformat() }}"
+      {% endif %}
+      onchange="updateDates();"
+    >
+    to
+    <input
+      id="endDate"
+      type="date"
+      {% if not end_is_default %}value="{{ end.isoformat() }}"{% endif %}
+      onchange="updateDates()"
+    >
+  </section>
+
   <section id="exclusionCookie">
     🔄 Checking if you have the exclusion cookie…
   </section>

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -112,7 +112,7 @@
   </div>
 
   <div class="chart">
-    <h1>{{ unique_users|map(attribute='unique_session_count')|sum|intcomma }} unique visitors</h1>
+    <h1>{{ unique_visitors|map(attribute='count')|sum|intcomma }} unique visitors</h1>
 
     <div>
       <canvas id="uniqueVisitorsChart"></canvas>
@@ -291,12 +291,12 @@
       type: 'line',
       data: {
         labels: [
-          {% for row in unique_users %}'{{ row.day|prettydate }}',{% endfor %}
+          {% for row in unique_visitors %}'{{ row.day|prettydate }}',{% endfor %}
         ],
         datasets: [{
           label: 'unique visitors',
           data: [
-            {% for row in unique_users %}{{ row.unique_session_count }},{% endfor %}
+            {% for row in unique_visitors %}{{ row.count }},{% endfor %}
           ],
           borderWidth: 1,
           fill: true,

--- a/test_app.py
+++ b/test_app.py
@@ -1,0 +1,100 @@
+import datetime
+import random
+
+import pytest
+from sqlite_utils import Database
+
+from app import AnalyticsDatabase, PerDayCount
+
+
+@pytest.fixture
+def analytics_db() -> AnalyticsDatabase:
+    return AnalyticsDatabase(db=Database(":memory:"))
+
+
+@pytest.mark.parametrize(
+    ["start_date", "end_date", "expected_result"],
+    [
+        ("2001-01-01", "2001-01-01", [{"day": "2001-01-01", "count": 10}]),
+        (
+            "2001-01-01",
+            "2001-01-02",
+            [{"day": "2001-01-01", "count": 10}, {"day": "2001-01-02", "count": 15}],
+        ),
+        (
+            "2001-01-02",
+            "2001-01-04",
+            [
+                {"day": "2001-01-02", "count": 15},
+                {"day": "2001-01-03", "count": 0},
+                {"day": "2001-01-04", "count": 17},
+            ],
+        ),
+    ],
+)
+def test_count_requests_per_day(
+    start_date: str, end_date: str, expected_result: list[PerDayCount]
+):
+    db = Database(":memory:")
+    analytics_db = AnalyticsDatabase(db)
+
+    requests = {"2001-01-01": 10, "2001-01-02": 15, "2001-01-04": 17, "2001-01-05": 16}
+
+    for day, count in requests.items():
+        for i in range(count):
+            db["events"].insert(
+                {"date": day + "T01:23:45Z", "is_me": False, "host": "alexwlchan.net"}
+            )
+
+    actual = analytics_db.count_requests_per_day(
+        start_date=datetime.date.fromisoformat(start_date),
+        end_date=datetime.date.fromisoformat(end_date),
+    )
+    assert actual == expected_result
+
+
+@pytest.mark.parametrize(
+    ["start_date", "end_date", "expected_result"],
+    [
+        ("2001-01-01", "2001-01-01", [{"day": "2001-01-01", "count": 10}]),
+        (
+            "2001-01-01",
+            "2001-01-02",
+            [{"day": "2001-01-01", "count": 10}, {"day": "2001-01-02", "count": 15}],
+        ),
+        (
+            "2001-01-02",
+            "2001-01-04",
+            [
+                {"day": "2001-01-02", "count": 15},
+                {"day": "2001-01-03", "count": 0},
+                {"day": "2001-01-04", "count": 17},
+            ],
+        ),
+    ],
+)
+def test_count_unique_visitors_per_day(
+    start_date: str, end_date: str, expected_result: list[PerDayCount]
+):
+    db = Database(":memory:")
+    analytics_db = AnalyticsDatabase(db)
+
+    requests = {"2001-01-01": 10, "2001-01-02": 15, "2001-01-04": 17, "2001-01-05": 16}
+
+    for day, visitor_count in requests.items():
+        for visitor_id in range(visitor_count):
+            for i in range(random.randint(1, 10)):
+                db["events"].insert(
+                    {
+                        "date": day + "T01:23:45Z",
+                        "session_id": visitor_id,
+                        "is_me": False,
+                        "host": "alexwlchan.net",
+                    }
+                )
+
+    actual = analytics_db.count_unique_visitors_per_day(
+        start_date=datetime.date.fromisoformat(start_date),
+        end_date=datetime.date.fromisoformat(end_date),
+    )
+    assert actual == expected_result


### PR DESCRIPTION
This adds a rudimentary date range picker, so I can focus on requests from a specific date if that's useful:

<img width="501" alt="Screenshot 2024-03-31 at 10 06 57" src="https://github.com/alexwlchan/analytics.alexwlchan.net/assets/301220/3646cdb6-4820-4821-a7b1-ffaea8aca319">

e.g. I had a spike in hits yesterday, because somebody posted the "big PDF" fact [on Twitter](https://twitter.com/amazingmap/status/1774124070960787574) and Threads, and somebody else is dropping my post in the replies to debunk it.