### PR TITLE
Don't count rows with an unknown country in the per-country stats

### DIFF
--- a/src/analytics/app.py
+++ b/src/analytics/app.py
@@ -230,6 +230,7 @@ class AnalyticsDatabase:
                 events
             WHERE
                 {self._where_clause(start_date, end_date)}
+                AND country IS NOT NULL
             GROUP BY
                 country
             """

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -183,10 +183,10 @@ def test_count_visitors_by_country(
     db = Database(":memory:")
     analytics_db = AnalyticsDatabase(db)
 
-    requests = {
+    requests: dict[str, dict[str | None, int]] = {
         "2001-01-01": {"US": 10, "GB": 5},
         "2001-01-02": {"US": 3, "GB": 4, "DE": 2},
-        "2001-01-04": {"GB": 7},
+        "2001-01-04": {"GB": 7, None: 3},
         "2001-01-05": {"US": 8, "FI": 6},
     }
 


### PR DESCRIPTION
This is a follow-on to https://github.com/alexwlchan/analytics.alexwlchan.net/pull/20 – I was getting an error when trying to draw the world map, because you can't plot `None` on a map anywhere.

There's nothing useful to do with rows without a country in that context, so just drop them.