### PR TITLE
Expand list of referrers

### DIFF
--- a/src/analytics/app.py
+++ b/src/analytics/app.py
@@ -456,7 +456,7 @@ def dashboard() -> str:
 
     missing_pages = find_missing_pages()
 
-    grouped_referrers = analytics_db.count_referrers(start_date, end_date)
+    counted_referrers = analytics_db.count_referrers(start_date, end_date)
 
     country_names = {
         country: get_country_name(country) for country in visitors_by_country
@@ -476,7 +476,7 @@ def dashboard() -> str:
         unique_visitors=unique_visitors,
         popular_pages=popular_pages,
         missing_pages=list(missing_pages),
-        grouped_referrers=grouped_referrers,
+        counted_referrers=counted_referrers,
         visitors_by_country=visitors_by_country,
         country_names=country_names,
         recent_posts=recent_posts,

--- a/src/analytics/referrers.py
+++ b/src/analytics/referrers.py
@@ -289,6 +289,7 @@ def normalise_referrer(referrer: str | None) -> str | None:
         "LinkedIn": ["www.linkedin.com", "lnkd.in"],
         "Linkhut": ["ln.ht"],
         "Lobsters": ["lobste.rs"],
+        "Mastodon": ["hachyderm.io"],
         "MSN": ["www.msn.com"],
         "MetaFilter": ["www.metafilter.com"],
         "Microsoft Office": [

--- a/src/analytics/referrers.py
+++ b/src/analytics/referrers.py
@@ -224,6 +224,10 @@ def normalise_referrer(referrer: str | None) -> str | None:
         "Baidu": ["m.baidu.com"],
         "Bluesky": ["bsky.app", "staging.bsky.app"],
         "ChatGPT": ["chat.openai.com"],
+        "Chat apps (Messenger, Snapchat, etc.)": [
+            "www.snapchat.com",
+            "messages.google.com",
+        ],
         "Email": [
             "email.t-online.de",
             "mailchi.mp",
@@ -298,7 +302,7 @@ def normalise_referrer(referrer: str | None) -> str | None:
         ],
         "Microsoft Teams": ["teams.microsoft.com"],
         "Pinboard": ["pinboard.in", "m.pinboard.in", "www.pinboard.in"],
-        "Pinterest": ["www.pinterest.de"],
+        "Pinterest": ["www.pinterest.de", "www.pinterest.com"],
         "PyPI": ["pypi.org"],
         "Reddit": [
             "reddit.com",
@@ -310,6 +314,7 @@ def normalise_referrer(referrer: str | None) -> str | None:
         ],
         "Skype": ["web.skype.com"],
         "Slashdot": ["slashdot.org", "m.slashdot.org", "it.slashdot.org"],
+        "Spotify": ["open.spotify.com"],
         "Substack": ["link.sbstck.com", "substack.com"],
         "Telegram": ["web.telegram.org", "weba.telegram.org"],
         "Tencent": ["t.cn"],

--- a/src/analytics/static/style.css
+++ b/src/analytics/static/style.css
@@ -52,12 +52,28 @@ a.reset {
   text-decoration: none;
 }
 
+button {
+  background: #ddd;
+  border: none;
+  border-radius: 5px;
+  padding: 4px 6px;
+}
+
+button:active {
+  margin-top: 2px;
+  margin-bottom: -2px;
+}
+
+button:hover {
+  background: #306b0077;
+}
+
 code {
   font-size: 1.2em;
 }
 
-.referrer_name:not(:first-child) td {
-  padding-top: 16px;
+tbody:not(:first-child) .referrer_name td {
+  padding-top: 24px;
 }
 
 .referrer_name {

--- a/src/analytics/templates/charts/referrers.html
+++ b/src/analytics/templates/charts/referrers.html
@@ -1,0 +1,54 @@
+{#
+  This component shows a list of referrers, grouped by referrer name.
+  Parameters:
+
+      :param counted_referrers: an instance of ``CountedReferrers``.
+
+#}
+
+<h1>Referrers</h1>
+
+<table>
+  {% for referrer, pages in counted_referrers.grouped_referrers %}
+    <tr class="referrer_name">
+      <td class="referrer">{{ referrer }}</td>
+      <td class="count">{{ pages.values()|sum|intcomma }}</td>
+    </tr>
+
+    {% set selected_amount = 4 if pages|length <= 4 else 3 %}
+
+    {# A cheap hack to update a variable outside a loop #}
+    {# See https://stackoverflow.com/a/29581974/1558022 #}
+    {% set remaining_total = {'total': pages.values()|sum} %}
+
+    {% for p, c in pages.most_common(selected_amount) %}
+      <tr class="referrer_page">
+        <td>&rarr; {{ p.replace(' – alexwlchan', '') }}</td>
+        {% set _ = remaining_total.update({'total': remaining_total['total'] - c}) %}
+        <td class="count">{{ c|intcomma }}</td>
+
+      </tr>
+    {% endfor %}
+
+    {% if pages|length > selected_amount %}
+      <tr class="referrer_page">
+        <td style="padding-left: 6px;">+ {{ pages|length - selected_amount }} other pages</td>
+        <td class="count">{{ remaining_total['total']|intcomma }}</td>
+      </tr>
+    {% endif %}
+  {% endfor %}
+
+  {% for page_title, source in counted_referrers.long_tail.items() %}
+    <tr class="referrer_name">
+      <td class="referrer">{{ page_title.replace(' – alexwlchan', '') }}</td>
+      <td class="count">{{ source|length|intcomma }}</td>
+    </tr>
+
+    {% for s, count in source.most_common() %}
+      <tr class="referrer_page">
+        <td class="referrer">&larr; {{ s }}</td>
+        <td class="count">{{ count|intcomma }}</td>
+      </tr>
+    {% endfor %}
+  {% endfor %}
+</table>

--- a/src/analytics/templates/charts/referrers.html
+++ b/src/analytics/templates/charts/referrers.html
@@ -8,6 +8,20 @@
 
 <h1>Referrers</h1>
 
+<script>
+  function displayAllReferrers(buttonElement) {
+    const tdElement = buttonElement.parentElement;
+    const trElement = tdElement.parentElement;
+    const tbodyElement = trElement.parentElement;
+
+    tbodyElement.querySelectorAll('tr').forEach(tr =>
+      tr.style.display = 'table-row'
+    );
+
+    trElement.style.display = 'none';
+  }
+</script>
+
 <table>
   {% for referrer, pages in counted_referrers.grouped_referrers %}
     <tr class="referrer_name">
@@ -21,21 +35,25 @@
     {# See https://stackoverflow.com/a/29581974/1558022 #}
     {% set remaining_total = {'total': pages.values()|sum} %}
 
-    {% for p, c in pages.most_common(selected_amount) %}
-      <tr class="referrer_page">
-        <td>&rarr; {{ p.replace(' – alexwlchan', '') }}</td>
-        {% set _ = remaining_total.update({'total': remaining_total['total'] - c}) %}
-        <td class="count">{{ c|intcomma }}</td>
+    <tbody>
+      {% for p, c in pages.most_common() %}
+        <tr class="referrer_page" {% if loop.index > selected_amount %}style="display: none;"{% endif %}>
+          <td>&rarr; {{ p.replace(' – alexwlchan', '') }}</td>
+          {% if loop.index <= selected_amount %}
+            {% set _ = remaining_total.update({'total': remaining_total['total'] - c}) %}
+          {% endif %}
+          <td class="count">{{ c|intcomma }}</td>
+        </tr>
+      {% endfor %}
 
-      </tr>
-    {% endfor %}
-
-    {% if pages|length > selected_amount %}
-      <tr class="referrer_page">
-        <td style="padding-left: 6px;">+ {{ pages|length - selected_amount }} other pages</td>
-        <td class="count">{{ remaining_total['total']|intcomma }}</td>
-      </tr>
-    {% endif %}
+      {% if pages|length > selected_amount %}
+        <tr class="referrer_page">
+          <td style="padding-left: 6px;">
+            <button onclick="displayAllReferrers(this);">+ {{ pages|length - selected_amount }} other pages</button></td>
+          <td class="count">{{ remaining_total['total']|intcomma }}</td>
+        </tr>
+      {% endif %}
+    </tbody>
   {% endfor %}
 
   {% for page_title, source in counted_referrers.long_tail.items() %}

--- a/src/analytics/templates/dashboard.html
+++ b/src/analytics/templates/dashboard.html
@@ -188,53 +188,7 @@
   </div>
 
   <div class="chart">
-    <h1>Referrers</h1>
-
-    <table>
-      {% for referrer, pages in grouped_referrers.grouped_referrers %}
-      <tr class="referrer_name">
-        <td class="referrer">{{ referrer }}</td>
-        <td class="count">{{ pages.values()|sum|intcomma }}</td>
-      </tr>
-
-      {% set selected_amount = 4 if pages|length <= 4 else 3 %}
-
-      {# A cheap hack to update a variable outside a loop #}
-      {# See https://stackoverflow.com/a/29581974/1558022 #}
-      {% set remaining_total = {'total': pages.values()|sum} %}
-
-      {% for p, c in pages.most_common(selected_amount) %}
-      <tr class="referrer_page">
-        <td>&rarr; {{ p.replace(' – alexwlchan', '') }}</td>
-        {% set _ = remaining_total.update({'total': remaining_total['total'] - c}) %}
-        <td class="count">{{ c|intcomma }}</td>
-
-      </tr>
-      {% endfor %}
-
-      {% if pages|length > selected_amount %}
-      <tr class="referrer_page">
-        <td style="padding-left: 6px;">+ {{ pages|length - selected_amount }} other pages</td>
-        <td class="count">{{ remaining_total['total']|intcomma }}</td>
-      </tr>
-      {% endif %}
-
-      {% endfor %}
-
-      {% for page_title, source in grouped_referrers.long_tail.items() %}
-      <tr class="referrer_name">
-        <td class="referrer">{{ page_title.replace(' – alexwlchan', '') }}</td>
-        <td class="count">{{ source|length|intcomma }}</td>
-      </tr>
-
-      {% for s, count in source.most_common() %}
-        <tr class="referrer_page">
-          <td class="referrer">&larr; {{ s }}</td>
-          <td class="count">{{ count|intcomma }}</td>
-        </tr>
-      {% endfor %}
-      {% endfor %}
-    </table>
+    {% include "charts/referrers.html" %}
   </div>
 
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>


### PR DESCRIPTION
Currently my list of referrers just shows the top three pages that a source referred to me, and then "+N pages":

<img width="590" alt="Screenshot 2024-05-04 at 09 19 55" src="https://github.com/alexwlchan/analytics.alexwlchan.net/assets/301220/5bd25e10-d7b3-4cc1-bc88-b3af14eb7a93">

This is mildly frustrating if I want to dig into the data in more details, so I've added a "see more" button which expands the full list on a one-off basis:

<img width="588" alt="Screenshot 2024-05-04 at 09 20 14" src="https://github.com/alexwlchan/analytics.alexwlchan.net/assets/301220/b00087f7-8e36-4452-9f70-b6ebfd86e044">

<img width="591" alt="Screenshot 2024-05-04 at 09 20 22" src="https://github.com/alexwlchan/analytics.alexwlchan.net/assets/301220/c7bffe98-909e-497f-b60e-dc0bb105ec5c">
