### PR TITLE
Fold the method for finding missing pages into database.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ source = [
 [tool.coverage.report]
 show_missing = true
 skip_covered = true
-fail_under = 89
+fail_under = 90
 # fail_under = 100
 
 [tool.pytest.ini_options]

--- a/src/analytics/database.py
+++ b/src/analytics/database.py
@@ -191,7 +191,7 @@ class AnalyticsDatabase:
             GROUP BY
                 path, normalised_referrer
             ORDER BY
-              count desc
+                count desc
         """
         )
 

--- a/src/analytics/database.py
+++ b/src/analytics/database.py
@@ -244,6 +244,11 @@ class AnalyticsDatabase:
         We can't see the page status code in JavaScript, so we can't sent it to the
         tracking pixel -- we have to look for the 404 page title.
         """
+        # Skip paths that end in `/null`.
+        #
+        # I see a handful of URLs like this -- I don't really know where
+        # they're coming from, but they're infrequent enough that I think
+        # it's a client issue rather than an issue on my site.
         cursor = self.db.query(
             f"""
             SELECT
@@ -253,6 +258,7 @@ class AnalyticsDatabase:
             WHERE
                 {self._where_clause(start_date, end_date)}
                 and title = '404 Not Found – alexwlchan'
+                and path NOT LIKE '%/null'
             GROUP BY
                 path
             ORDER BY

--- a/src/analytics/templates/charts/popular_posts.html
+++ b/src/analytics/templates/charts/popular_posts.html
@@ -27,13 +27,17 @@
 
 <h1 style="margin-top: 2em;">Missing pages</h1>
 
-<table>
-  {% for p in missing_pages %}
-  <tr>
-    <td>
-      <code style="overflow-wrap: anywhere;">{{ p.path }}</p>
-    </td>
-    <td class="count">{{ p.count }}</td>
-  </tr>
-  {% endfor %}
-</table>
+{% if missing_pages %}
+  <table>
+    {% for p in missing_pages %}
+    <tr>
+      <td>
+        <code style="overflow-wrap: anywhere;">{{ p.path }}</p>
+      </td>
+      <td class="count">{{ p.count }}</td>
+    </tr>
+    {% endfor %}
+  </table>
+{% else %}
+  <p>Nobody got a 404 page in this period! 🥳</p>
+{% endif %}

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -249,5 +249,4 @@ class TestAnalyticsDatabase:
         assert result == [
             {"path": "/not-found", "count": 5},
             {"path": "/404", "count": 2},
-            {"path": "/files/2021/null", "count": 1},
         ]


### PR DESCRIPTION
Previously it would just get the last 30 days; now it gets the missing pages that fall within the selected period. This makes this list behave like the rest of the page.

I've also added some basic tests, and started filtering a common pattern of 404s.