### PR TITLE
Remove an unused warning filter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,24 +22,7 @@ fail_under = 94
 # fail_under = 100
 
 [tool.pytest.ini_options]
-filterwarnings = [
-  "error",
-
-  # This hides a deprecation warning in dateutil:
-  #
-  #     dateutil/tz/tz.py:37: DeprecationWarning:
-  #     datetime.datetime.utcfromtimestamp() is deprecated and scheduled
-  #     for removal in a future version. Use timezone-aware objects to
-  #     represent datetimes in UTC:
-  #     datetime.datetime.fromtimestamp(timestamp, datetime.UTC).
-  #
-  # There's a fix for this in main, but it's not been released to PyPI yet,
-  # e.g. see https://github.com/dateutil/dateutil/issues/1284
-  #
-  # When we upgrade to a version of python-dateutil that includes
-  # this fix (>2.8.2), we can remove this filter.
-  "ignore::DeprecationWarning:dateutil*:",
-]
+filterwarnings = ["error"]
 
 [tool.mypy]
 mypy_path = "src"


### PR DESCRIPTION
This warning is never actually thrown in my tests, so I don't need to filter it out.